### PR TITLE
Use json-stringify-safe

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
  */
 "use strict";
 const EventEmitter = require('events');
+const stringify = require('json-stringify-safe');
 
 /**
  * @class LambdaLog
@@ -93,7 +94,7 @@ class LambdaLog extends EventEmitter {
         
         if(!this.config.silent) {
             let method = level === 'debug'? 'log' : level;
-            console[method](JSON.stringify(data, null, this.config.dev? 4 : 0));
+            console[method](stringify(data, null, this.config.dev? 4 : 0));
         }
         
         /**

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   },
   "devDependencies": {
     "mocha": "^3.2.0"
+  },
+  "dependencies": {
+    "json-stringify-safe": "^5.0.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -2,8 +2,10 @@
 const assert = require('assert');
 const log = require('./');
 
-// Silence logs for testing
-log.config.silent = true;
+beforeEach(function() {
+    // Silence logs for testing
+    log.config.silent = true;
+})
 
 describe('Module', function() {
     it('should return a new instance', function() {
@@ -102,6 +104,16 @@ describe('LambdaLog', function() {
             it('should have logLevel', function() {
                 let logData = log.log('error', 'Test log level');
                 assert.equal(logData._logLevel, 'error');
+            });
+
+            it('should not throw for circular objects', function() {
+                log.config.silent = false;
+                const circularObj = {};
+                circularObj.circularRef = circularObj;
+                circularObj.list = [ circularObj, circularObj ];
+                assert.doesNotThrow(function () {
+                    log.log('error', circularObj);
+                });
             });
         });
         


### PR DESCRIPTION
Use `json-stringify-safe` to avoid errors when logging objects with circular references.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kyleross/node-lambda-log/8)
<!-- Reviewable:end -->
