### PR TITLE
Fix stream option to work correctly

### DIFF
--- a/lib/LambdaLog.js
+++ b/lib/LambdaLog.js
@@ -122,7 +122,7 @@ class LambdaLog extends EventEmitter {
         if(!method) return false;
         
         if(!this.options.silent) {
-            console[method](message.toJSON(this.options.dev));
+            this.console[method](message.toJSON(this.options.dev));
         }
 
         /**


### PR DESCRIPTION
Now, global console object is refered unintentionally at LambdaLog.
Fix it to work correctly.