### PR TITLE
Release 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "11"
   - "10"
   - "9"
   - "8"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # LambdaLog Changelog 
 
+## 2.1.0 (12/19/2018)
+* **BREAKING:** Removed `stdoutStream` and `stderrStream` options.
+* **NEW:** Added `logHandler` option which takes a `console`-like object to send logs through. (#11)
+
 ## 2.0.1 (12/7/2018)
 * Fix console logging pointing to global `console` instead of custom console instance for streaming. (@sh1n1chi8acker - #10)
 * Update mocha to v5.2.0

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Keep in mind that custom implementations must be synchronus. If you need it to b
 const log = require('lambda-log');
 
 // example using `Console` instance
-const Console = require('console');
+const { Console } = require('console');
 log.options.logHandler = new Console(myStdoutStream, myStderrStream);
 
 // or with a console-like object

--- a/lib/LambdaLog.js
+++ b/lib/LambdaLog.js
@@ -43,10 +43,6 @@ class LambdaLog extends EventEmitter {
             silent: false,
             // Optional replacer function for `JSON.stringify`
             replacer: null,
-            // Optional stream to write stdout messages to
-            stdoutStream: process.stdout,
-            // Optional stream to write stderr messages to
-            stderrStream: process.stderr
         }, options);
         
         /**

--- a/lib/LambdaLog.js
+++ b/lib/LambdaLog.js
@@ -1,5 +1,4 @@
 "use strict";
-const { Console } = require('console');
 const EventEmitter = require('events');
 
 const LogMessage = require('./LogMessage');
@@ -43,6 +42,8 @@ class LambdaLog extends EventEmitter {
             silent: false,
             // Optional replacer function for `JSON.stringify`
             replacer: null,
+            // Console-like object to log messages to
+            logHandler: console
         }, options);
         
         /**
@@ -62,10 +63,10 @@ class LambdaLog extends EventEmitter {
         this._levels = Object.keys(this._logLevels);
         
         /**
-         * Instance of `Console` used for logging
+         * Console-like log handler to use for logging messages
          * @type {Object}
          */
-        this.console = new Console(this.options.stdoutStream, this.options.stderrStream);
+        this.console = this.options.logHandler;
 
         this._levels.forEach((lvl) => {
             /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-log",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Basic logging mechanism for Node 6.10+ Lambda Functions",
   "main": "index.js",
   "scripts": {

--- a/test/lambdaLog.js
+++ b/test/lambdaLog.js
@@ -16,8 +16,7 @@ describe('LambdaLog', function() {
             assert(log.options.dev === false);
             assert(log.options.silent === false);
             assert(log.options.replacer === null);
-            assert(log.options.stdoutStream === process.stdout);
-            assert(log.options.stderrStream === process.stderr);
+            assert(log.options.logHandler === console);
         });
         
         it ('should override default options', () => {
@@ -25,15 +24,13 @@ describe('LambdaLog', function() {
                 meta: { test: true },
                 tags: ['test'],
                 dynamicMeta: function() { /*empty*/ },
-                silent: true,
-                stderrStream: process.stdout
+                silent: true
             });
             
             assert(log.options.meta.test === true);
             assert(log.options.tags.length === 1 && log.options.tags[0] === 'test');
             assert(typeof log.options.dynamicMeta === 'function');
             assert(log.options.silent === true);
-            assert(log.options.stderrStream === process.stdout);
         });
         
         describe('Log Levels', function() {
@@ -80,15 +77,6 @@ describe('LambdaLog', function() {
                     assert(typeof log.fatal === 'function');
                     assert(typeof log.rainbow === 'function');
                 });
-            });
-        });
-        
-        describe('Console', () => {
-            it('should create a custom instance of console', () => {
-                let { Console } = require('console'),
-                    log = new LambdaLog();
-                
-                assert(log.console instanceof Console);
             });
         });
     });


### PR DESCRIPTION
Contains fix for #11 that caused certain metadata added by AWS to be removed from the logs in CloudWatch Logs. This has brought forth a breaking change to the package.

In order to solve the issue, I need to remove the `stdoutStream` and `stderrStream` options from the LambdaLog class. Lambda Log no longer creates a custom `Console` instance by default and instead utilizes the global `console` object. By removing these options, a new option, `logHandler` has been added which can be a custom `Console` instance or a `console`-like object. This allows the previous functionality to exist, but in a different fashion for those users who need it. By default, `logHandler` is set to the global `console` object.

I apologize to anyone who has implemented the options from version 2.0.0, but this is important to ensure consistent logs for the majority of users. To implement the same functionality from 2.0.0 in version 2.1.0, you can do the following:

```js
const log = require('lambda-log');
const { Console}  = require('console');

log.options.logHandler = new Console(process.stdout, process.stderr);
```