### PR TITLE
fix: change debug log method (#21)

### DIFF
--- a/lib/LambdaLog.js
+++ b/lib/LambdaLog.js
@@ -73,7 +73,7 @@ class LambdaLog extends EventEmitter {
             warn: 'warn',
             error: 'error',
             debug: function() {
-                if(this.options.debug) return 'log';
+                if(this.options.debug) return 'debug';
                 return false;
             }
         }, levels || {});


### PR DESCRIPTION
Change console method for debug from`log` to `debug` in order for the log to be labeled `DEBUG` within Cloudwatch Logs.