### PR TITLE
Fix {Any} to {*} per jsdoc

### DIFF
--- a/lib/LambdaLog.js
+++ b/lib/LambdaLog.js
@@ -117,7 +117,7 @@ class LambdaLog extends EventEmitter {
      * and emitted through an event. If an `Error` or `Error`-like object is provided for `msg`, it will parse out the message and include the stacktrace in the metadata.
      * @throws {Error} If improper log level is provided.
      * @param  {String} level Log level (`info`, `debug`, `warn`, `error` or a [custom log level](#custom-log-levels))
-     * @param  {Any}    msg   Message to log. Can be any type, but string or `Error` reccommended.
+     * @param  {*}      msg   Message to log. Can be any type, but string or `Error` reccommended.
      * @param  {Object} [meta={}]  Optional meta data to attach to the log.
      * @param  {Array}  [tags=[]]  Additional tags to append to this log.
      * @return {LogMessage|Boolean}  Returns instance of LogMessage or `false` if `level = "debug"` and `options.debug = false`. May also return `false` when a [custom log level](#custom-log-levels) handler function prevents the log from being logged.
@@ -171,8 +171,8 @@ class LambdaLog extends EventEmitter {
      * Generates a log message if `test` is a falsy value. If `test` is truthy, the log message is skipped and returns `false`. Allows creating log messages without the need to 
      * wrap them in an if statement. The log level will be `error`.
      * @since  1.4.0
-     * @param  {Any}            test      A value which is tested for a falsy value.
-     * @param  {Any}            msg       Message to log if `test` is falsy. Can be any type, but string or `Error` reccommended.
+     * @param  {*}              test      A value which is tested for a falsy value.
+     * @param  {*}              msg       Message to log if `test` is falsy. Can be any type, but string or `Error` reccommended.
      * @param  {Object}         [meta={}] Optional meta data to attach to the log.
      * @param  {Array}          [tags=[]] Additional tags to append to this log.
      * @return {LogMessage|Boolean}       The LogMessage instance for the log or `false` if test passed.

--- a/lib/LogMessage.js
+++ b/lib/LogMessage.js
@@ -138,7 +138,7 @@ class LogMessage {
     /**
      * Checks if value is an Error or Error-like object
      * @private
-     * @param  {Any}     val Value to test
+     * @param  {*}       val Value to test
      * @return {Boolean}     Whether the value is an Error or Error-like object
      */
     static isError(val) {


### PR DESCRIPTION
`{Any}` ends up being interpreted as an object/class that's literally called `Any`. JSDoc calls for `{*}` to be used when you don't care about the type passed in.