### PR TITLE
feat: set loglevel

### DIFF
--- a/lib/LambdaLog.js
+++ b/lib/LambdaLog.js
@@ -10,7 +10,7 @@ const symbols = {
  * @property {object} [meta={}] Global metadata to be included in all logs.
  * @property {string[]|Function[]} [tags=[]] Global tags to be included in all logs.
  * @property {Function} [dynamicMeta=null] Function that runs for each log that returns additional metadata. See [Dynamic Metadata](#dynamic-metadata).
- * @property {boolean} [debug=false] Enables `log.debug()`.
+ * @property {string} [logLevel=info] Sets the loglevel
  * @property {boolean} [dev=false] Enable development mode which pretty-prints JSON to the console.
  * @property {boolean} [silent=false] Disables logging to `console` but messages and events are still generated.
  * @property {Function} [replacer=null] Replacer function for `JSON.stringify()` to allow handling of sensitive data before logs are written. See [JSON.stringify](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The_replacer_parameter).
@@ -30,7 +30,7 @@ class LambdaLog extends EventEmitter {
    * via `log.LambdaLog`.
    * @class
    * @param {LambdaLogOptions}                 [options={}] Options for configuring LambdaLog.
-   * @param {object.<string, string|Function>} [levels={}]  Allows adding and customizing log levels.
+   * @param {object.<string, [string, number]>} [levels={}]  Allows adding and customizing log levels.
    */
   constructor(options = {}, levels = {}) {
     super();
@@ -55,10 +55,10 @@ class LambdaLog extends EventEmitter {
       meta: {},
       tags: [],
       dynamicMeta: null,
-      debug: false,
       dev: false,
       silent: ['true', 'yes', 'y', '1'].includes(process.env.LAMBDALOG_SILENT),
       replacer: null,
+      logLevel: 'info',
       logHandler: console,
       levelKey: '_logLevel',
       messageKey: 'msg',
@@ -68,16 +68,14 @@ class LambdaLog extends EventEmitter {
 
     /**
      * Global configuration for log levels
-     * @type {object}
+     * @type {object.<string, [string, number]>}
      */
     this[symbols.LEVELS] = {
-      info: 'info',
-      warn: 'warn',
-      error: 'error',
-      debug() {
-        if(this.options.debug) return 'debug';
-        return false;
-      },
+      off: ['log', 200],
+      error: ['error', 300],
+      warn: ['warn', 400],
+      info: ['info', 500],
+      debug: ['debug', 600],
       ...levels
     };
 
@@ -93,6 +91,21 @@ class LambdaLog extends EventEmitter {
         this.addLevel(lvl, levelsConfig[lvl]);
       }
     }
+
+    // set the loglevel
+    this.setLogLevel(this.options.logLevel);
+  }
+
+  /**
+   * Sets to logger to a specific loglevel
+   * @param {string} level the loglevel which should be set
+   */
+  setLogLevel(level) {
+    if(!this[symbols.LEVELS][level]) {
+      throw new Error(`"${level}" does not exists as log level`);
+    }
+
+    this.options.logLevel = level;
   }
 
   /**
@@ -143,15 +156,12 @@ class LambdaLog extends EventEmitter {
       tags
     }, this.options);
 
-    let method = this[symbols.LEVELS][level];
+    // get the method and numLevel of the message level
+    const [method, numLevel] = this[symbols.LEVELS][level];
+    // get the level which is configured
+    const configuredNumLevel = this[symbols.LEVELS][this.options.logLevel][1];
 
-    if(typeof method === 'function') {
-      method = method.call(this, message);
-    }
-
-    if(!method) return false;
-
-    if(!this.options.silent) {
+    if(!this.options.silent && numLevel <= configuredNumLevel) {
       this.console[method](message.toJSON(this.options.dev));
     }
 
@@ -193,13 +203,11 @@ class LambdaLog extends EventEmitter {
       throw new Error('A promise must be provided as the first argument');
     }
 
-    const wrapper = new Promise(resolve => {
+    return new Promise(resolve => {
       promise
         .then(value => resolve(this.log('info', value, meta, tags)))
         .catch(err => resolve(this.log('error', err, meta, tags)));
     });
-
-    return wrapper;
   }
 }
 

--- a/lib/LambdaLog.test.js
+++ b/lib/LambdaLog.test.js
@@ -34,7 +34,6 @@ describe('Constructor', () => {
     ['meta', {}],
     ['tags', []],
     ['dynamicMeta', null],
-    ['debug', false],
     ['dev', false],
     ['silent', false],
     ['replacer', null],
@@ -50,7 +49,6 @@ describe('Constructor', () => {
     ['meta', { test: 'test' }],
     ['tags', ['custom-tag']],
     ['dynamicMeta', function () {}],
-    ['debug', true],
     ['dev', true],
     ['silent', true],
     ['replacer', function () {}],
@@ -110,29 +108,15 @@ describe('Properties', () => {
     });
 
     test('should have default log level info', () => {
-      expect(log[LambdaLog.symbols.LEVELS]).toHaveProperty('info', 'info');
+      expect(log[LambdaLog.symbols.LEVELS]).toHaveProperty('info', ['info', 500]);
     });
 
     test('should have default log level warn', () => {
-      expect(log[LambdaLog.symbols.LEVELS]).toHaveProperty('warn', 'warn');
+      expect(log[LambdaLog.symbols.LEVELS]).toHaveProperty('warn', ['warn', 400]);
     });
 
     test('should have default log level error', () => {
-      expect(log[LambdaLog.symbols.LEVELS]).toHaveProperty('error', 'error');
-    });
-
-    test('should have default log level debug', () => {
-      expect(log[LambdaLog.symbols.LEVELS]).toHaveProperty('debug');
-      expect(typeof log[LambdaLog.symbols.LEVELS].debug).toBe('function');
-    });
-
-    test('should return false from debug level function when options.debug is false', () => {
-      expect(log[LambdaLog.symbols.LEVELS].debug.call(log)).toBe(false);
-    });
-
-    test('should return debug from debug level function when options.debug is true', () => {
-      const log = new LambdaLog({ debug: true });
-      expect(log[LambdaLog.symbols.LEVELS].debug.call(log)).toBe('debug');
+      expect(log[LambdaLog.symbols.LEVELS]).toHaveProperty('error', ['error', 300]);
     });
   });
 
@@ -158,6 +142,30 @@ describe('Methods', () => {
     });
   });
 
+  describe('setLogLevel()', () => {
+    test('should not log a message when a specific loglevel is set', () => {
+      log = new LambdaLog({ logHandler: mockConsole, silent: false });
+      log.setLogLevel('error');
+      log.info('foo', 'test');
+      expect(mockConsole.info).toBeCalledTimes(0);
+      log.setLogLevel('info');
+      log.info('foo', 'test');
+      expect(mockConsole.info).toBeCalledTimes(1);
+    });
+
+    test('should not log anything when loglevel is "off"', () => {
+      log = new LambdaLog({ logHandler: mockConsole, silent: false });
+      log.setLogLevel('off');
+      log.info('test');
+      log.debug('another test');
+      expect(mockConsole.info).toBeCalledTimes(0);
+    });
+
+    test('should not be able to set an invalid loglevel', () => {
+      expect(() => new LambdaLog({ logHandler: mockConsole, logLevel: 'no' })).toThrow();
+    });
+  });
+
   describe('log()', () => {
     test('should throw error when unknown log level is passed in', () => {
       expect(() => {
@@ -165,9 +173,9 @@ describe('Methods', () => {
       }).toThrow('"foo" is not a valid log level');
     });
 
-    test('should return false for a disable log level', () => {
-      const result = log.log('debug', 'test');
-      expect(result).toBe(false);
+    test('should not log for a disabled log level (debug)', () => {
+      log.log('debug', 'test');
+      expect(mockConsole.debug).toBeCalledTimes(0);
     });
 
     test('should not log message when silent is enabled', () => {
@@ -257,7 +265,7 @@ describe('Dynamic Methods', () => {
     const log = new LambdaLog({
       logHandler: mockConsole,
       silent: false,
-      debug: true
+      logLevel: method
     });
 
     expect(typeof log[method]).toBe('function');
@@ -270,10 +278,9 @@ describe('Dynamic Methods', () => {
   test('should automatically create method for custom log levels', () => {
     const log = new LambdaLog({
       logHandler: mockConsole,
-      silent: false,
-      debug: true
+      silent: false
     }, {
-      test: 'log'
+      test: ['log', 300]
     });
 
     expect(typeof log.test).toBe('function');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and review
the requirements below.

Bug fixes and new features should include tests.
-->
### Type of Change
<!-- Please provide the type of change. Either "Bug Fix" or "New Feature" here. -->
New Feature to set a specific loglevel and do not log anything below that level. It also incoorperates with custom loglevels. I did not change the documentation yet since I'm awaiting your feedback on the PR. For me it is reasonable and also works nicely with custom level. So no big change. As this repo is mainly used for aws lambda setting fine granular loglevels can save lots of cloudwatch costs.

### Description of Change(s)
<!-- Please provide a description of the change(s) here. -->
Changed the Levels like:
```javascript
this[symbols.LEVELS] = {
  off: ['log', 200],
  error: ['error', 300],
  warn: ['warn', 400],
  info: ['info', 500],
  debug: ['debug', 600],
  ...levels
};
```

to enable a classic loglevel setting. I removed the debug option and added the level more implicit. This works with custom level too.

#### Checklist
<!-- For completed items, change [ ] to [x]. -->

- [ x] Commit messages are in proper Conventional Commits format.
- [ x] Tests updated or added (if applicable).
- [x] Test coverage remains at 100%.
- [ x] There are no errors or warning in ESLint.
- [ ] Documentation updated (if applicable).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
